### PR TITLE
Closes #158 Set default Java version to 11.0.18-tem for SDKMAN! users

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=8.0.345-tem
+java=11.0.18-tem


### PR DESCRIPTION
The Java version mentioned in the .sdkmanrc is updated to Java 11. Users that have SDKMAN! installed will automatically switch to the defined Java version when they enter the workshop directory.